### PR TITLE
Add OpenAPI documentation with Swagger UI

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,12 @@
-# TODO 
+# Task Management Backend
 
-- Create a Database Schema  
-- Create Springboot Application with (Web, Database, Liquibase)
-- Provide CRUD Endpoints
+This service provides project, task and note management APIs built with Spring Boot.
+
+## API documentation
+
+Interactive OpenAPI documentation is available once the application is running:
+
+- Swagger UI: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+- OpenAPI JSON: [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)
+
+The documentation is generated automatically from controller annotations using Springdoc.

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,15 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.7.0</version>
+        </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>

--- a/src/main/java/com/task_management/config/OpenApiConfig.java
+++ b/src/main/java/com/task_management/config/OpenApiConfig.java
@@ -1,0 +1,28 @@
+package com.task_management.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Task Management API",
+                version = "v1",
+                description = "REST API for managing projects, tasks and notes.",
+                contact = @Contact(name = "Task Management Team", email = "support@example.com")
+        ),
+        servers = {
+                @Server(url = "http://localhost:8080", description = "Local Server")
+        },
+        tags = {
+                @Tag(name = "Projects", description = "Operations about projects"),
+                @Tag(name = "Tasks", description = "Operations about tasks"),
+                @Tag(name = "Notes", description = "Operations about notes")
+        }
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/task_management/controller/ProjectController.java
+++ b/src/main/java/com/task_management/controller/ProjectController.java
@@ -4,9 +4,14 @@ import com.task_management.dto.ProjectCreateReq;
 import com.task_management.dto.ProjectRes;
 import com.task_management.dto.ProjectUpdateReq;
 import com.task_management.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -24,34 +29,76 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/projects")
 @RequiredArgsConstructor
+@Tag(name = "Projects")
 public class ProjectController {
 
     private final ProjectService projectService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "Create a project",
+            description = "Creates a new project with the provided details.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Project created"),
+                    @ApiResponse(responseCode = "400", description = "Validation failure")
+            }
+    )
     public ProjectRes create(@Valid @RequestBody ProjectCreateReq req) {
         return projectService.create(req);
     }
 
     @GetMapping("/{projectId}")
-    public ProjectRes get(@PathVariable UUID projectId) {
+    @Operation(
+            summary = "Get project",
+            description = "Retrieves the details of a project by its identifier.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Project found"),
+                    @ApiResponse(responseCode = "404", description = "Project not found")
+            }
+    )
+    public ProjectRes get(@Parameter(description = "Project identifier") @PathVariable UUID projectId) {
         return projectService.get(projectId);
     }
 
     @GetMapping
-    public Page<ProjectRes> list(@PageableDefault(size = 20) Pageable pageable) {
+    @Operation(
+            summary = "List projects",
+            description = "Returns a paginated list of projects ordered by name.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Page of projects retrieved")
+            }
+    )
+    public Page<ProjectRes> list(@ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return projectService.list(pageable);
     }
 
     @PatchMapping("/{projectId}")
-    public ProjectRes update(@PathVariable UUID projectId, @Valid @RequestBody ProjectUpdateReq req) {
+    @Operation(
+        summary = "Update project",
+        description = "Updates project details for the given identifier.",
+        responses = {
+                @ApiResponse(responseCode = "200", description = "Project updated"),
+                @ApiResponse(responseCode = "404", description = "Project not found"),
+                @ApiResponse(responseCode = "400", description = "Validation failure")
+        }
+    )
+    public ProjectRes update(@Parameter(description = "Project identifier") @PathVariable UUID projectId,
+                            @Valid @RequestBody ProjectUpdateReq req) {
         return projectService.update(projectId, req);
     }
 
     @DeleteMapping("/{projectId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID projectId) {
+    @Operation(
+            summary = "Delete project",
+            description = "Removes the project permanently.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Project deleted"),
+                    @ApiResponse(responseCode = "404", description = "Project not found")
+            }
+    )
+    public void delete(@Parameter(description = "Project identifier") @PathVariable UUID projectId) {
         projectService.delete(projectId);
     }
 }

--- a/src/main/java/com/task_management/controller/TaskController.java
+++ b/src/main/java/com/task_management/controller/TaskController.java
@@ -4,9 +4,14 @@ import com.task_management.dto.TaskCreateReq;
 import com.task_management.dto.TaskRes;
 import com.task_management.dto.TaskUpdateReq;
 import com.task_management.service.TaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -25,35 +30,80 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/tasks")
 @RequiredArgsConstructor
+@Tag(name = "Tasks")
 public class TaskController {
 
     private final TaskService taskService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "Create task",
+            description = "Creates a new task within a project.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Task created"),
+                    @ApiResponse(responseCode = "400", description = "Validation failure"),
+                    @ApiResponse(responseCode = "404", description = "Project not found")
+            }
+    )
     public TaskRes create(@Valid @RequestBody TaskCreateReq req) {
         return taskService.create(req);
     }
 
     @GetMapping("/{taskId}")
-    public TaskRes get(@PathVariable UUID taskId) {
+    @Operation(
+            summary = "Get task",
+            description = "Retrieves a task by its identifier.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Task found"),
+                    @ApiResponse(responseCode = "404", description = "Task not found")
+            }
+    )
+    public TaskRes get(@Parameter(description = "Task identifier") @PathVariable UUID taskId) {
         return taskService.get(taskId);
     }
 
     @GetMapping
-    public Page<TaskRes> listByProject(@RequestParam("projectId") UUID projectId,
-                                       @PageableDefault(size = 20) Pageable pageable) {
+    @Operation(
+            summary = "List project tasks",
+            description = "Returns a paginated list of tasks for the specified project.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Page of tasks retrieved"),
+                    @ApiResponse(responseCode = "404", description = "Project not found")
+            }
+    )
+    public Page<TaskRes> listByProject(@Parameter(description = "Project identifier")
+                                       @RequestParam("projectId") UUID projectId,
+                                       @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return taskService.listInProject(projectId, pageable);
     }
 
     @PatchMapping("/{taskId}")
-    public TaskRes update(@PathVariable UUID taskId, @Valid @RequestBody TaskUpdateReq req) {
+    @Operation(
+            summary = "Update task",
+            description = "Updates the details of a task.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Task updated"),
+                    @ApiResponse(responseCode = "404", description = "Task not found"),
+                    @ApiResponse(responseCode = "400", description = "Validation failure")
+            }
+    )
+    public TaskRes update(@Parameter(description = "Task identifier") @PathVariable UUID taskId,
+                          @Valid @RequestBody TaskUpdateReq req) {
         return taskService.update(taskId, req);
     }
 
     @DeleteMapping("/{taskId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID taskId) {
+    @Operation(
+            summary = "Delete task",
+            description = "Deletes the specified task.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Task deleted"),
+                    @ApiResponse(responseCode = "404", description = "Task not found")
+            }
+    )
+    public void delete(@Parameter(description = "Task identifier") @PathVariable UUID taskId) {
         taskService.delete(taskId);
     }
 }


### PR DESCRIPTION
## Summary
- add the Springdoc OpenAPI UI dependency and configuration for the task management API
- annotate project, task, and note controllers with descriptive OpenAPI metadata
- refresh the README with links to the generated Swagger UI and JSON docs

## Testing
- mvn test *(fails: unable to download Spring Boot parent POM because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cccdc1e9e4832ba2a7e6c670f57b5a