### PR TITLE
Add structured logging and document Promtail integration

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,6 +2,28 @@
 
 This service provides project, task and note management APIs built with Spring Boot.
 
+## Logging and observability
+
+- Logback writes structured JSON logs to `/var/log/task-management/app.log` inside the container while keeping the colourised console output for local debugging.
+- Both Docker Compose definitions bind mount the repository's `logs/` directory to that path (`./logs` in the root compose file and `../logs` in `infra/docker-compose.yml`), so the host gets a rolling set of files such as `logs/app.log` and `logs/app.log.2024-05-20.0.gz`.
+- Override the location by setting the `LOGGING_FILE_NAME` environment variable if you need a different target path.
+
+### Scraping the logs with Promtail
+
+Point Promtail at the mounted directory on the host. A minimal scrape configuration looks like:
+
+```
+scrape_configs:
+  - job_name: task-management
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: task-management
+          __path__: /path/to/repo/logs/app.log*
+```
+
+Replace `/path/to/repo` with the absolute path of your clone. Promtail will tail both the active file and any rotated files and forward them to Loki.
+
 ## API documentation
 
 Interactive OpenAPI documentation is available once the application is running (the service listens on port `8002` by default):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: task-management-service
+    volumes:
+      - ./logs:/var/log/task-management
     ports:
       - "8002:8002"
     environment:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -22,6 +22,8 @@ services:
   springboot-app:
     image: ghcr.io/genzitizens/task-management:latest
     container_name: task-management-service
+    volumes:
+      - ../logs:/var/log/task-management
     environment:
       # DB
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${SPRING_DATASOURCE_DB}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>8.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.7.0</version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,10 @@
 # App
 spring.application.name=task-management
 
+# Logging
+logging.config=classpath:logback-spring.xml
+logging.file.name=${LOGGING_FILE_NAME:/var/log/task-management/app.log}
+
 # Datasource
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/TaskDB}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:username}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty scope="context" name="APP_LOG_FILE" source="logging.file.name"
+                    defaultValue="/var/log/task-management/app.log"/>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"
+                    defaultValue="task-management"/>
+
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${APP_LOG_FILE}</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${APP_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service_name":"${APP_NAME}"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="JSON_FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add a Logback configuration that keeps console output and streams JSON logs to a rolling file for Promtail/Loki
- include the Logstash encoder dependency and point Spring Boot at the new logging configuration
- bind mount the container log directory in both docker-compose variants and document how to scrape it with Promtail

## Testing
- ./mvnw test *(fails: unable to resolve Spring Boot parent due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d21639e89c832bb3761ae2191a999c