### PR TITLE
Add actuator health checks and metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,20 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-		<dependency>
+                <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/src/main/java/com/task_management/monitoring/ApplicationHealthIndicator.java
+++ b/src/main/java/com/task_management/monitoring/ApplicationHealthIndicator.java
@@ -1,0 +1,34 @@
+package com.task_management.monitoring;
+
+import com.task_management.repository.ProjectRepository;
+import com.task_management.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Contributes domain specific information to the actuator health endpoint while
+ * also ensuring the persistence layer can be reached.
+ */
+@Component
+@RequiredArgsConstructor
+public class ApplicationHealthIndicator implements HealthIndicator {
+
+    private final ProjectRepository projectRepository;
+    private final TaskRepository taskRepository;
+
+    @Override
+    public Health health() {
+        try {
+            long projectCount = projectRepository.count();
+            long taskCount = taskRepository.count();
+            return Health.up()
+                    .withDetail("projects.count", projectCount)
+                    .withDetail("tasks.count", taskCount)
+                    .build();
+        } catch (Exception exception) {
+            return Health.down(exception).build();
+        }
+    }
+}

--- a/src/main/java/com/task_management/monitoring/TaskMetrics.java
+++ b/src/main/java/com/task_management/monitoring/TaskMetrics.java
@@ -1,0 +1,40 @@
+package com.task_management.monitoring;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Central place to register and update custom Micrometer counters for the application.
+ */
+@Component
+public class TaskMetrics {
+
+    private final Counter tasksCreated;
+    private final Counter tasksUpdated;
+    private final Counter tasksDeleted;
+
+    public TaskMetrics(MeterRegistry meterRegistry) {
+        this.tasksCreated = Counter.builder("task_management.tasks.created")
+                .description("Number of tasks created")
+                .register(meterRegistry);
+        this.tasksUpdated = Counter.builder("task_management.tasks.updated")
+                .description("Number of tasks updated")
+                .register(meterRegistry);
+        this.tasksDeleted = Counter.builder("task_management.tasks.deleted")
+                .description("Number of tasks deleted")
+                .register(meterRegistry);
+    }
+
+    public void incrementCreated() {
+        tasksCreated.increment();
+    }
+
+    public void incrementUpdated() {
+        tasksUpdated.increment();
+    }
+
+    public void incrementDeleted() {
+        tasksDeleted.increment();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,12 @@ spring.liquibase.change-log=${SPRING_LIQUIBASE_CHANGE_LOG:classpath:db/changelog
 # Server port (let env SERVER_PORT override)
 server.port=${SERVER_PORT:8002}
 
-# Optional: don?t run Spring?s SQL initializer
+# Optional: don't run Spring's SQL initializer
 spring.sql.init.mode=never
+
+# Actuator configuration
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=always
+management.metrics.tags.application=${spring.application.name}
+management.metrics.export.prometheus.enabled=true

--- a/src/test/java/com/task_management/monitoring/ActuatorIntegrationTest.java
+++ b/src/test/java/com/task_management/monitoring/ActuatorIntegrationTest.java
@@ -1,0 +1,42 @@
+package com.task_management.monitoring;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.metrics.MetricsEndpoint;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ActuatorIntegrationTest {
+
+    @Autowired
+    private HealthEndpoint healthEndpoint;
+
+    @Autowired
+    private MetricsEndpoint metricsEndpoint;
+
+    @Autowired
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+
+    @Test
+    void healthEndpointReportsUpStatus() {
+        assertEquals(Status.UP, healthEndpoint.health().getStatus());
+    }
+
+    @Test
+    void customTaskMetricsAreRegistered() {
+        assertNotNull(metricsEndpoint.metric("task_management.tasks.created", null));
+    }
+
+    @Test
+    void prometheusRegistryExportsCustomCounter() {
+        String scrape = prometheusMeterRegistry.scrape();
+        assertTrue(scrape.contains("task_management_tasks_created_total"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Boot Actuator and Prometheus registry dependencies
- expose health/metrics endpoints and register counters for task lifecycle events
- contribute a custom health indicator plus tests that verify actuator wiring

## Testing
- ./mvnw test *(fails: unable to download dependencies because the Maven Central network endpoint is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a6984f0c832ba6fc6d653a797dc7