### PR TITLE
Fix Prometheus scrape test for Spring Boot 3.5

### DIFF
--- a/src/test/java/com/task_management/monitoring/ActuatorIntegrationTest.java
+++ b/src/test/java/com/task_management/monitoring/ActuatorIntegrationTest.java
@@ -5,11 +5,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusOutputFormat;
 import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusScrapeEndpoint;
-import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusScrapeEndpoint.PrometheusOutputFormat;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,7 +41,10 @@ class ActuatorIntegrationTest {
 
     @Test
     void prometheusRegistryExportsCustomCounter() {
-        String scrape = prometheusScrapeEndpoint.scrape(PrometheusOutputFormat.TEXT, Set.of());
+        WebEndpointResponse<byte[]> response = prometheusScrapeEndpoint.scrape(PrometheusOutputFormat.TEXT, Set.of());
+        assertEquals(WebEndpointResponse.STATUS_OK, response.getStatus());
+        assertNotNull(response.getBody());
+        String scrape = new String(response.getBody(), StandardCharsets.UTF_8);
         assertTrue(scrape.contains("task_management_tasks_created_total"));
     }
 }


### PR DESCRIPTION
## Summary
- update the actuator integration test to import the standalone PrometheusOutputFormat type
- adjust the Prometheus scrape assertion to work with the WebEndpointResponse body returned in Spring Boot 3.5

## Testing
- `./mvnw test` *(fails: Unable to download org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from Maven Central due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b2eb8204832ba4d6f9af04408104