### PR TITLE
Fix default log file path for local runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Logs
+logs/

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,9 +4,9 @@ This service provides project, task and note management APIs built with Spring B
 
 ## Logging and observability
 
-- Logback writes structured JSON logs to `/var/log/task-management/app.log` inside the container while keeping the colourised console output for local debugging.
+- By default Logback writes structured JSON logs to `logs/app.log` (relative to the working directory) while keeping the colourised console output for local debugging.
+- Override the location by setting the `LOGGING_FILE_NAME` environment variable if you need a different target path. The provided Docker Compose definitions set it to `/var/log/task-management/app.log`.
 - Both Docker Compose definitions bind mount the repository's `logs/` directory to that path (`./logs` in the root compose file and `../logs` in `infra/docker-compose.yml`), so the host gets a rolling set of files such as `logs/app.log` and `logs/app.log.2024-05-20.0.gz`.
-- Override the location by setting the `LOGGING_FILE_NAME` environment variable if you need a different target path.
 
 ### Scraping the logs with Promtail
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
       SPRING_DATASOURCE_USERNAME: username
       SPRING_DATASOURCE_PASSWORD: password
 
+      # Logging
+      LOGGING_FILE_NAME: /var/log/task-management/app.log
+
       # If you want to use the mounted changelog instead of classpath:
       SPRING_LIQUIBASE_CHANGE_LOG: classpath:db/changelog/changelog-master.sql
       SPRING_JPA_HIBERNATE_DDL_AUTO: validate

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
 
+      # Logging
+      LOGGING_FILE_NAME: /var/log/task-management/app.log
+
       # Liquibase
       SPRING_LIQUIBASE_CHANGE_LOG: classpath:db/changelog/changelog-master.sql
       SPRING_JPA_HIBERNATE_DDL_AUTO: validate

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=task-management
 
 # Logging
 logging.config=classpath:logback-spring.xml
-logging.file.name=${LOGGING_FILE_NAME:/var/log/task-management/app.log}
+logging.file.name=${LOGGING_FILE_NAME:logs/app.log}
 
 # Datasource
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/TaskDB}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
     <springProperty scope="context" name="APP_LOG_FILE" source="logging.file.name"
-                    defaultValue="/var/log/task-management/app.log"/>
+                    defaultValue="logs/app.log"/>
     <springProperty scope="context" name="APP_NAME" source="spring.application.name"
                     defaultValue="task-management"/>
 


### PR DESCRIPTION
## Summary
- default the logging file location to a writable `logs/app.log` for local executions
- set the docker compose environments to continue writing logs to `/var/log/task-management/app.log`
- document the new default location and ignore generated log directories

## Testing
- ./mvnw test *(fails: unable to reach Maven Central to download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bb313e48832b9f50fa1bee0cccee