### PR TITLE
chore: centralize logging filter constants

### DIFF
--- a/src/main/java/com/task_management/config/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/task_management/config/RequestResponseLoggingFilter.java
@@ -21,6 +21,8 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestResponseLoggingFilter.class);
     private static final int MAX_PAYLOAD_LENGTH = 2000;
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+    private static final String TRUNCATION_SUFFIX = "...(truncated)";
 
     @Override
     protected void doFilterInternal(
@@ -102,7 +104,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
             return "<binary or large payload omitted>";
         }
 
-        Charset charset = StandardCharsets.UTF_8;
+        Charset charset = DEFAULT_CHARSET;
         if (encoding != null && !encoding.isBlank()) {
             try {
                 charset = Charset.forName(encoding);
@@ -112,7 +114,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
         }
         String payload = new String(buf, charset);
         if (payload.length() > MAX_PAYLOAD_LENGTH) {
-            return payload.substring(0, MAX_PAYLOAD_LENGTH) + "...(truncated)";
+            return payload.substring(0, MAX_PAYLOAD_LENGTH) + TRUNCATION_SUFFIX;
         }
         return payload;
     }


### PR DESCRIPTION
## Summary
- add shared constants for the default charset and truncation suffix in the request/response logging filter
- reuse the new constants when truncating payloads to keep the configuration consistent

## Testing
- `./mvnw test` *(fails: unable to download Spring Boot parent POM because outbound network access to Maven Central is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c8daf400832b8a69c3a302b98c7f